### PR TITLE
Feature/add priority to todo

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -23,7 +23,7 @@ axiosInstance.interceptors.request.use(
       );
     }
 
-    config.headers.Authorization = `Bearer ${token}`;
+    config.headers.Authorization = token;
 
     return config;
   },

--- a/src/components/todo/TodoDetailSection/TodoDetailSection.tsx
+++ b/src/components/todo/TodoDetailSection/TodoDetailSection.tsx
@@ -5,6 +5,7 @@ import { formatToYYYYMMDD } from "@/utils/formatDate";
 import { useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import styles from "./TodoDetailSection.module.css";
+import TodoLabel from "../TodoLabel";
 
 interface TodoDetailSectionPropsType {
   deleteTodo: (todoId: string) => void;
@@ -67,6 +68,7 @@ export default function TodoDetailSection({
             <p>todo 불러오는 중</p>
           ) : (
             <>
+              <TodoLabel priority={todoData.priority} />
               <h3 className={styles.title}>{todoData.title}</h3>
               <div className={styles["date-container"]}>
                 <div className={styles["date-wrapper"]}>

--- a/src/components/todo/TodoEditSection/TodoEditSection.tsx
+++ b/src/components/todo/TodoEditSection/TodoEditSection.tsx
@@ -2,9 +2,15 @@ import TodoForm from "../TodoForm";
 import styles from "./TodoEditSection.module.css";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useGetTodo } from "@/features/todo/todoApi.query";
+import { TodoPriorityType } from "@/types/todo.type";
+import PRIORITY from "@/constants/todoPriority";
 
 interface TodoEditSectionPropsType {
-  updateTodo: (title: string, content: string) => void;
+  updateTodo: (
+    title: string,
+    content: string,
+    priority: TodoPriorityType
+  ) => void;
   isPutUpdateTodoPending?: boolean;
 }
 
@@ -23,8 +29,12 @@ export default function TodoEditSection({
   };
 
   /** 수정 완료 버튼 클릭 메서드 */
-  const onUpdateSubmit = (titleValue: string, contentValue: string) => {
-    updateTodo(titleValue, contentValue);
+  const onUpdateSubmit = (
+    titleValue: string,
+    contentValue: string,
+    priority: TodoPriorityType
+  ) => {
+    updateTodo(titleValue, contentValue, priority);
   };
 
   return (
@@ -35,6 +45,7 @@ export default function TodoEditSection({
         <TodoForm
           defaultTitle={todoData?.title || ""}
           defaultContent={todoData?.content || ""}
+          defaultPriority={todoData?.priority || PRIORITY.NORMAL}
           onSubmit={onUpdateSubmit}
           mainButton={{ text: "완료", isLoading: isPutUpdateTodoPending }}
           subButton={{

--- a/src/components/todo/TodoForm/TodoForm.module.css
+++ b/src/components/todo/TodoForm/TodoForm.module.css
@@ -21,3 +21,7 @@
   flex-direction: column;
   gap: 10px;
 }
+
+.field-wrapper.radio-field {
+  flex-direction: row;
+}

--- a/src/components/todo/TodoForm/TodoForm.tsx
+++ b/src/components/todo/TodoForm/TodoForm.tsx
@@ -4,11 +4,17 @@ import Label from "@/components/common/Label";
 import Input from "@/components/common/Input";
 import Textarea from "@/components/common/Textarea";
 import { useState } from "react";
+import PRIORITY from "@/constants/todoPriority";
+import { TodoPriorityType } from "@/types/todo.type";
 
 interface TodoFormPropsType {
   defaultTitle?: string;
   defaultContent?: string;
-  onSubmit: (titleValue: string, contentValue: string) => void;
+  onSubmit: (
+    titleValue: string,
+    contentValue: string,
+    priority: TodoPriorityType
+  ) => void;
   mainButton: {
     syleType?: "primary" | "secondary";
     text: string;
@@ -34,6 +40,8 @@ export default function TodoForm({
 }: TodoFormPropsType) {
   const [titleValue, setTitleValue] = useState(defaultTitle);
   const [contentValue, setContentValue] = useState(defaultContent);
+  const [selectedPriorityValue, setSelectedPriorityValue] =
+    useState<TodoPriorityType>(PRIORITY.NORMAL);
 
   const onTitleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
@@ -47,9 +55,16 @@ export default function TodoForm({
     setContentValue(newValue);
   };
 
+  const onSelectedPriorityChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const newValue = event.target.value as TodoPriorityType;
+    setSelectedPriorityValue(newValue);
+  };
+
   const onTodoSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    onSubmit(titleValue, contentValue);
+    onSubmit(titleValue, contentValue, selectedPriorityValue);
   };
 
   return (
@@ -77,6 +92,38 @@ export default function TodoForm({
       </header>
 
       <div className={styles["field-container"]}>
+        <div className={`${styles["field-wrapper"]} ${styles["radio-field"]}`}>
+          <label>
+            <input
+              type="radio"
+              name="priority"
+              value={PRIORITY.URGENT}
+              checked={selectedPriorityValue === PRIORITY.URGENT}
+              onChange={onSelectedPriorityChange}
+            />
+            Urgent
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="priority"
+              value={PRIORITY.NORMAL}
+              checked={selectedPriorityValue === PRIORITY.NORMAL}
+              onChange={onSelectedPriorityChange}
+            />
+            Normal
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="priority"
+              value={PRIORITY.LOW}
+              checked={selectedPriorityValue === PRIORITY.LOW}
+              onChange={onSelectedPriorityChange}
+            />
+            Low
+          </label>
+        </div>
         {/* title */}
         <div className={styles["field-wrapper"]}>
           <Label text="Title" isRequired htmlFor="title" />

--- a/src/components/todo/TodoForm/TodoForm.tsx
+++ b/src/components/todo/TodoForm/TodoForm.tsx
@@ -10,6 +10,7 @@ import { TodoPriorityType } from "@/types/todo.type";
 interface TodoFormPropsType {
   defaultTitle?: string;
   defaultContent?: string;
+  defaultPriority?: TodoPriorityType;
   onSubmit: (
     titleValue: string,
     contentValue: string,
@@ -34,6 +35,7 @@ interface TodoFormPropsType {
 export default function TodoForm({
   defaultTitle = "",
   defaultContent = "",
+  defaultPriority = PRIORITY.NORMAL,
   onSubmit,
   mainButton,
   subButton,
@@ -41,7 +43,7 @@ export default function TodoForm({
   const [titleValue, setTitleValue] = useState(defaultTitle);
   const [contentValue, setContentValue] = useState(defaultContent);
   const [selectedPriorityValue, setSelectedPriorityValue] =
-    useState<TodoPriorityType>(PRIORITY.NORMAL);
+    useState<TodoPriorityType>(defaultPriority);
 
   const onTitleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;

--- a/src/components/todo/TodoLabel/TodoLabel.module.css
+++ b/src/components/todo/TodoLabel/TodoLabel.module.css
@@ -1,0 +1,20 @@
+.label-wrapper {
+  border-radius: 20%;
+  padding: 8px;
+  height: fit-content;
+}
+
+.label-wrapper.urgent {
+  background-color: rgb(255, 83, 83);
+}
+.label-wrapper.normal {
+  background-color: rgb(0, 197, 92);
+}
+.label-wrapper.low {
+  background-color: rgb(102, 102, 102);
+}
+
+.label {
+  color: white;
+  font-size: 12px;
+}

--- a/src/components/todo/TodoLabel/TodoLabel.module.css
+++ b/src/components/todo/TodoLabel/TodoLabel.module.css
@@ -2,6 +2,7 @@
   border-radius: 20%;
   padding: 8px;
   height: fit-content;
+  width: fit-content;
 }
 
 .label-wrapper.urgent {

--- a/src/components/todo/TodoLabel/TodoLabel.tsx
+++ b/src/components/todo/TodoLabel/TodoLabel.tsx
@@ -1,0 +1,31 @@
+import PRIORITY from "@/constants/todoPriority";
+import style from "./TodoLabel.module.css";
+
+interface TodoLabelPropsType {
+  priority: (typeof PRIORITY)[keyof typeof PRIORITY];
+}
+
+export default function TodoLabel({ priority }: TodoLabelPropsType) {
+  let label = "";
+
+  switch (priority) {
+    case PRIORITY.URGENT: {
+      label = "높음";
+      break;
+    }
+    case PRIORITY.NORMAL: {
+      label = "보통";
+      break;
+    }
+    case PRIORITY.LOW: {
+      label = "낮음";
+      break;
+    }
+  }
+
+  return (
+    <div className={`${style["label-wrapper"]} ${style[priority]}`}>
+      <p className={`${style["label"]}`}> {label}</p>
+    </div>
+  );
+}

--- a/src/components/todo/TodoLabel/index.ts
+++ b/src/components/todo/TodoLabel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TodoLabel";

--- a/src/components/todo/TodoListSection/TodoListSection.module.css
+++ b/src/components/todo/TodoListSection/TodoListSection.module.css
@@ -21,7 +21,7 @@
 .todo-item {
   border-bottom: 1px solid #ffa322;
   display: flex;
-  justify-content: space-between;
+  gap: 10px;
   align-items: center;
   height: 50px;
 }
@@ -39,6 +39,7 @@
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
   max-width: 80%;
+  flex: 1;
 }
 
 .todo-last-update {

--- a/src/components/todo/TodoListSection/TodoListSection.tsx
+++ b/src/components/todo/TodoListSection/TodoListSection.tsx
@@ -3,6 +3,7 @@ import styles from "./TodoListSection.module.css";
 import Button from "@/components/common/Button";
 import { TodoListType } from "@/types/todo.type";
 import { formatToYYYYMMDD } from "@/utils/formatDate";
+import TodoLabel from "../TodoLabel";
 
 interface TodoListSectionPropsType {
   todos?: TodoListType;
@@ -32,6 +33,7 @@ export default function TodoListSection({
             <li key={todo.id}>
               <Link to={`/${todo.id}`} className={`${styles["todo-item"]}`}>
                 <p className={styles["todo-title"]}>{todo.title}</p>
+                <TodoLabel priority={todo.priority} />
                 <span className={styles["todo-last-update"]}>
                   {formatToYYYYMMDD(todo.updatedAt)}
                 </span>

--- a/src/constants/todoPriority.ts
+++ b/src/constants/todoPriority.ts
@@ -1,0 +1,7 @@
+const PRIORITY = {
+  URGENT: "urgent",
+  NORMAL: "normal",
+  LOW: "low",
+} as const;
+
+export default PRIORITY;

--- a/src/features/todo/todoApi.query.ts
+++ b/src/features/todo/todoApi.query.ts
@@ -165,7 +165,12 @@ export const useUpdateTodo = () => {
   } = useMutation({
     mutationKey: [QUERY_KEY.TODO.PUT_UPDATE_TODO],
     mutationFn: (reqParams: PutUpdateReqTodoType) =>
-      putUpdateTodo(reqParams.id, reqParams.title, reqParams.content),
+      putUpdateTodo(
+        reqParams.id,
+        reqParams.title,
+        reqParams.content,
+        reqParams.priority
+      ),
     onSuccess() {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.TODO.GET_TODOS],

--- a/src/features/todo/todoApi.query.ts
+++ b/src/features/todo/todoApi.query.ts
@@ -96,7 +96,7 @@ export const usePostCreateTodo = () => {
   } = useMutation({
     mutationKey: [QUERY_KEY.TODO.POST_CREATE_TODO],
     mutationFn: (newTodo: PostCreateReqTodoType) =>
-      postCreateTodo(newTodo.title, newTodo.content),
+      postCreateTodo(newTodo.title, newTodo.content, newTodo.priority),
     onSuccess() {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.TODO.GET_TODOS],

--- a/src/features/todo/todoApi.ts
+++ b/src/features/todo/todoApi.ts
@@ -42,11 +42,13 @@ export const deleteTodo = async (id: string) => {
 export const putUpdateTodo = async (
   id: string,
   title: string,
-  content: string
+  content: string,
+  priority: TodoPriorityType
 ) => {
   const response = await axiosInstance.put(`${API_PATHS.TODOS}/${id}`, {
     title,
     content,
+    priority,
   });
   return response.data;
 };

--- a/src/features/todo/todoApi.ts
+++ b/src/features/todo/todoApi.ts
@@ -1,6 +1,10 @@
 import { API_PATHS } from "@/constants/apiPaths";
 import axiosInstance from "../../api/axiosInstance";
-import { GetResTodosType, GetResTodoType } from "@/types/todo.type";
+import {
+  GetResTodosType,
+  GetResTodoType,
+  TodoPriorityType,
+} from "@/types/todo.type";
 
 /** todo 목록 */
 export const getTodos = async (): Promise<GetResTodosType> => {
@@ -15,10 +19,15 @@ export const getTodo = async (id: string): Promise<GetResTodoType> => {
 };
 
 /** todo 생성 */
-export const postCreateTodo = async (title: string, content: string) => {
+export const postCreateTodo = async (
+  title: string,
+  content: string,
+  priority: TodoPriorityType
+) => {
   const response = await axiosInstance.post(API_PATHS.TODOS, {
     title,
     content,
+    priority,
   });
   return response.data;
 };

--- a/src/pages/CreateTodoPage/CreateTodoPage.tsx
+++ b/src/pages/CreateTodoPage/CreateTodoPage.tsx
@@ -4,14 +4,19 @@ import { useNavigate } from "react-router-dom";
 import styles from "./CreateTodoPage.module.css";
 import { ROUTES } from "@/constants/routes";
 import { usePostCreateTodo } from "@/features/todo/todoApi.query";
+import { TodoPriorityType } from "@/types/todo.type";
 
 /** todo 작성 페이지 */
 export default function CreateTodoPage() {
   const navigate = useNavigate();
   const { mutatePostCreateTodo, isCreateTodoPending } = usePostCreateTodo();
 
-  const onCreateSubmit = async (title: string, content: string) => {
-    mutatePostCreateTodo({ title, content });
+  const onCreateSubmit = async (
+    title: string,
+    content: string,
+    priority: TodoPriorityType
+  ) => {
+    mutatePostCreateTodo({ title, content, priority });
   };
   const onCancelCreate = () => {
     navigate(ROUTES.HOME); // todo list 페이지 이동

--- a/src/pages/TodoPage/TodoPage.tsx
+++ b/src/pages/TodoPage/TodoPage.tsx
@@ -13,6 +13,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import styles from "./TodoPage.module.css";
+import { TodoPriorityType } from "@/types/todo.type";
 
 export default function TodoPage() {
   const { id } = useParams();
@@ -40,13 +41,17 @@ export default function TodoPage() {
    * - 수정 후 todo 목록 호출
    * - edit mode 취소
    */
-  const updateSettingTodo = async (title: string, content: string) => {
+  const updateSettingTodo = async (
+    title: string,
+    content: string,
+    priority: TodoPriorityType
+  ) => {
     if (!id) {
       navigate(ROUTES.HOME); // id없을 경우 루트경로로 리다이렉트
       return;
     }
     await mutateAsyncPutUpdateTodo(
-      { id, title, content },
+      { id, title, content, priority },
       {
         onSuccess() {
           queryClient.invalidateQueries({

--- a/src/pages/TodoPage/TodoPage.tsx
+++ b/src/pages/TodoPage/TodoPage.tsx
@@ -13,6 +13,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import styles from "./TodoPage.module.css";
+import TodoLabel from "@/components/todo/TodoLabel";
 
 export default function TodoPage() {
   const { id } = useParams();

--- a/src/pages/TodoPage/TodoPage.tsx
+++ b/src/pages/TodoPage/TodoPage.tsx
@@ -13,7 +13,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import styles from "./TodoPage.module.css";
-import TodoLabel from "@/components/todo/TodoLabel";
 
 export default function TodoPage() {
   const { id } = useParams();

--- a/src/types/todo.type.ts
+++ b/src/types/todo.type.ts
@@ -25,4 +25,7 @@ export type PostCreateReqTodoType = Pick<
   "title" | "content" | "priority"
 >;
 
-export type PutUpdateReqTodoType = Pick<TodoType, "id" | "title" | "content">;
+export type PutUpdateReqTodoType = Pick<
+  TodoType,
+  "id" | "title" | "content" | "priority"
+>;

--- a/src/types/todo.type.ts
+++ b/src/types/todo.type.ts
@@ -1,12 +1,17 @@
+import PRIORITY from "@/constants/todoPriority";
+
 export interface TodoType {
   title: string;
   content: string;
   id: string;
+  priority: TodoPriorityType;
   createdAt: string;
   updatedAt: string;
 }
 
 export type TodoListType = TodoType[];
+
+export type TodoPriorityType = (typeof PRIORITY)[keyof typeof PRIORITY];
 
 export interface GetResTodosType {
   data: TodoListType;
@@ -15,6 +20,9 @@ export interface GetResTodoType {
   data: TodoType;
 }
 
-export type PostCreateReqTodoType = Pick<TodoType, "title" | "content">;
+export type PostCreateReqTodoType = Pick<
+  TodoType,
+  "title" | "content" | "priority"
+>;
 
 export type PutUpdateReqTodoType = Pick<TodoType, "id" | "title" | "content">;


### PR DESCRIPTION
todo priority 필드 추가 및 관련 UI 업데이트

### 작업 내용
1. **todo 생성 시 priority 필드 추가**:
   - 새로운 todo를 생성할 때 priority 값을 설정할 수 있도록 필드 추가

2. **todo 수정 시 priority 필드 추가**:
   - 기존 todo의 priority 값을 수정할 수 있도록 기능 구현

3. **todo 목록, 상세에 priority 필드 추가**:
   - todo 목록 및 상세 페이지에서 priority 정보를 볼 수 있도록 UI 업데이트

4. **priority 라벨 컴포넌트 작업**:
   - priority 값을 시각적으로 구분할 수 있도록 라벨 컴포넌트를 추가

### 테스트
- todo 생성, 수정 시 정상적으로 priority 필드가 반영되는지 확인하였습니다.
- todo 목록과 상세 페이지에서 priority 값이 제대로 표시되는지 검증하였습니다.